### PR TITLE
Configurable locales + Clean code

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,89 @@
+<?php
+
+// Inspired from Laravel php_cs, converted to php-cs-fixer 2, and simplified.
+//  - https://github.com/laravel/framework/blob/5.4/.php_cs
+//  - http://cs.sensiolabs.org/
+//  - https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/UPGRADE.md
+// Removed: not_operator_with_successor_space, phpdoc_no_package, phpdoc_summary, unary_operator_spaces
+
+$excludes = [
+    'bootstrap/cache',
+    'node_modules',
+    'resources/lang',
+    'storage',
+    'vendor',
+];
+
+$rules = [
+    '@PSR2' => true,
+    'blank_line_after_opening_tag' => true,
+    'braces' => true,
+    'concat_space' => ['spacing' => 'none'],
+    'no_multiline_whitespace_around_double_arrow' => true,
+    'no_empty_statement' => true,
+    'simplified_null_return' => true,
+    'encoding' => true,
+    'single_blank_line_at_eof' => true,
+    'no_extra_consecutive_blank_lines' => true,
+    'no_spaces_after_function_name' => true,
+    'function_declaration' => true,
+    'include' => true,
+    'indentation_type' => true,
+    'no_alias_functions' => true,
+    'blank_line_after_namespace' => true,
+    'line_ending' => true,
+    'no_trailing_comma_in_list_call' => true,
+    'lowercase_constants' => true,
+    'lowercase_keywords' => true,
+    'method_argument_space' => true,
+    'trailing_comma_in_multiline_array' => true,
+    'no_multiline_whitespace_before_semicolons' => true,
+    'single_import_per_statement' => true,
+    'no_leading_namespace_whitespace' => true,
+    'no_blank_lines_after_class_opening' => true,
+    'no_blank_lines_after_phpdoc' => true,
+    'object_operator_without_whitespace' => true,
+    'binary_operator_spaces' => true,
+    'no_spaces_inside_parenthesis' => true,
+    'phpdoc_indent' => true,
+    'phpdoc_inline_tag' => true,
+    'phpdoc_no_access' => true,
+    'phpdoc_scalar' => true,
+    'phpdoc_to_comment' => true,
+    'phpdoc_trim' => true,
+    'phpdoc_no_alias_tag' => true,
+    'phpdoc_var_without_name' => true,
+    'no_leading_import_slash' => true,
+    'no_extra_consecutive_blank_lines' => true,
+    'blank_line_before_return' => true,
+    'self_accessor' => true,
+    'array_syntax' => ['syntax' => 'short'],
+    'no_short_echo_tag' => true,
+    'full_opening_tag' => true,
+    'no_trailing_comma_in_singleline_array' => true,
+    'single_blank_line_before_namespace' => true,
+    'single_line_after_imports' => true,
+    'single_quote' => true,
+    'no_singleline_whitespace_before_semicolons' => true,
+    'cast_spaces' => true,
+    'standardize_not_equals' => true,
+    'ternary_operator_spaces' => true,
+    'no_trailing_whitespace' => true,
+    'trim_array_spaces' => true,
+    'binary_operator_spaces' => ['align_equals' => false],
+    'no_unused_imports' => true,
+    'visibility_required' => true,
+    'no_whitespace_in_blank_line' => true,
+];
+
+$finder = PhpCsFixer\Finder::create()
+    ->name('*.php')
+    ->exclude($excludes)
+    ->notPath('server.php')
+    ->ignoreDotFiles(true)
+    ->in(__DIR__);
+
+return PhpCsFixer\Config::create()
+    ->setRules($rules)
+    ->setFinder($finder)
+    ->setUsingCache(true);

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: php
+
+php:
+  - 7.1
+
+sudo: false
+
+cache:
+    directories:
+      - $HOME/.composer/cache
+
+before_script:
+  - php -v
+  - composer install
+
+script:
+  - composer run-script lint
+  - composer run-script test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,3 @@ before_script:
 
 script:
   - composer run-script lint
-  - composer run-script test

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In order for the translation manager to be accessible trought the sidebar in the
 
 ```html
 <li>
-    <a href="{{ url(config('backpack.base.route_prefix', 'admin').'/'.config('translation-manager.route_prefix')) }}"><i class="fa fa-cog"></i> <span>{{ trans('translation-manager::app.translation') }}</span></a>
+    <a href="{{ url(config('backpack.base.route_prefix', 'admin').'/'.config('translation-manager.route_prefix')) }}"><i class="fa fa-cog"></i> <span>{{ trans('translation-manager::crud.sidebar_title') }}</span></a>
 </li>
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please follow these instructions: https://github.com/spatie/laravel-translation-
 ```php?start_inline=1
 'providers' => [
     // ...
-    Novius\Backpack\Translation\Manager\TranslationServiceProvider::class,
+    Novius\Backpack\Translation\Manager\Providers\TranslationServiceProvider::class,
 ]
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     ],
     "require": {
         "php": ">=7.1",
-        "backpack/base": "^0.7.19",
-        "spatie/laravel-translation-loader": "^1.2.1"
+        "backpack/base": "^0.8 || ^0.7.19",
+        "spatie/laravel-translation-loader": "^2.0 || 1.2.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.10.0"

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
-        "backpack/base": "^0.7.19",
-        "spatie/laravel-translation-loader": "^1.2.1"
+        "php": ">=7.1",
+        "backpack/base": "^0.7.19", 
+       "spatie/laravel-translation-loader": "^1.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,6 @@
     "scripts": {
         "lint" : [
             "php-cs-fixer fix --dry-run --config .php_cs -vv --diff --allow-risky=yes"
-        ],
-        "test" : [
-            "phpunit"
         ]
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=7.1",
-        "backpack/base": "^0.7.19", 
-       "spatie/laravel-translation-loader": "^1.2.1"
+        "backpack/base": "^0.7.19",
+        "spatie/laravel-translation-loader": "^1.2.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,14 @@
 {
     "name": "novius/laravel-backpack-translation-manager",
     "description": "This packages provides an interface to manage translations via the Backpack admin panel",
+    "keywords": [
+        "Novius",
+        "Laravel",
+        "Backpack",
+        "Translation",
+        "Manager",
+        "I18N"
+    ],
     "type": "library",
     "license": "AGPL-3.0-or-later",
     "authors": [
@@ -14,9 +22,30 @@
         "backpack/base": "^0.7.19",
         "spatie/laravel-translation-loader": "^1.2.1"
     },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "~2.10.0"
+    },
     "autoload": {
         "psr-4": {
             "Novius\\Backpack\\Translation\\Manager\\": "src"
         }
+    },
+    "scripts": {
+        "lint" : [
+            "php-cs-fixer fix --dry-run --config .php_cs -vv --diff --allow-risky=yes"
+        ],
+        "test" : [
+            "phpunit"
+        ]
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Novius\\Backpack\\Translation\\Providers\\TranslationServiceProvider"
+            ]
+        }
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Novius\\Backpack\\Translation\\Providers\\TranslationServiceProvider"
+                "Novius\\Backpack\\Translation\\Manager\\Providers\\TranslationServiceProvider"
             ]
         }
     },

--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -1,6 +1,40 @@
 <?php
 
 return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Admin controller
+    |--------------------------------------------------------------------------
+    |
+    | The controller class used for the translations admin panel.
+    |
+    */
     'admin_controller_class' => Novius\Backpack\Translation\Manager\Http\Controllers\Admin\TranslationController::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Admin route prefix
+    |--------------------------------------------------------------------------
+    |
+    | The route prefix used for the translations admin panel.
+    |
+    */
     'route_prefix' => 'translation',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Available locales
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the list of locales that will be available in the translations admin panel.
+    | If not set or null, the list will be automatically generated from the dictionaries found.
+    |
+    */
+    // 'locales' => [
+    //     'fr',
+    //     'en',
+    //     'de',
+    //     'pt_BR',
+    // ],
 ];

--- a/resources/lang/en/crud.php
+++ b/resources/lang/en/crud.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'title' => 'Translation Manager',
+    'subtitle' => 'All translations of your site',
+    'sidebar_title' => 'Translations',
+    'breadcrumb_list' => 'List',
+    'select_dictionary_label' => 'Dictionary',
+    'select_dictionary_default_option' => '-- Select a dictionary --',
+    'select_language_label' => 'Language',
+    'select_language_default_option' => '-- Select a language --',
+    'column_key' => 'Key',
+    'column_translation' => 'Translation',
+    'list_no_translations' => 'No translations available for this dictionary.',
+    'list_require_select' => 'Select a dictionary and a language to display translations.',
+    'button_search' => 'Search',
+    'button_save' => 'Save translations',
+];

--- a/resources/lang/fr/app.php
+++ b/resources/lang/fr/app.php
@@ -1,5 +1,0 @@
-<?php
-
-return [
-    'translation' => 'Traductions'
-];

--- a/resources/lang/fr/crud.php
+++ b/resources/lang/fr/crud.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'title' => 'Gestionnaire de traductions',
+    'subtitle' => 'Toutes les traductions de votre site',
+    'sidebar_title' => 'Traductions',
+    'breadcrumb_list' => 'Liste',
+    'select_dictionary_label' => 'Dictionnaire',
+    'select_dictionary_default_option' => '-- Selectionnez un dictionnaire --',
+    'select_language_label' => 'Langue',
+    'select_language_default_option' => '-- Selectionnez une langue --',
+    'column_key' => 'Clé',
+    'column_translation' => 'Traduction',
+    'list_no_translations' => 'Aucune traduction disponible pour ce dictionnaire.',
+    'list_require_select' => 'Selectionnez un dictionnaire et une langue pour afficher les traductions.',
+    'button_search' => 'Rechercher',
+    'button_save' => 'Sauvegarder les traductions',
+];

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -3,18 +3,20 @@
 @section('header')
     <section class="content-header">
       <h1>
-        {{ trans('translation-manager::app.index_title') }}
-          <small>{{ trans('translation-manager::app.index_subtitle') }}</small>
+        {{ trans('translation-manager::crud.title') }}
+          <small>{{ trans('translation-manager::crud.subtitle') }}</small>
       </h1>
       <ol class="breadcrumb">
           <li>
               <a href="{{ url(config('backpack.base.route_prefix'), 'dashboard') }}">{{ trans('backpack::crud.admin') }}</a>
           </li>
           <li>
-              <a href="{{ url(config('backpack.base.route_prefix').'/'.config('translation-manager.route_prefix')) }}">{{ trans('translation-manager::app.index_title') }}</a>
+              <a href="{{ url(config('backpack.base.route_prefix').'/'.config('translation-manager.route_prefix')) }}">
+                  {{ trans('translation-manager::crud.title') }}
+              </a>
           </li>
           <li class="active">
-              {{ trans('translation-manager::app.list') }}
+              {{ trans('translation-manager::crud.breadcrumb_list') }}
           </li>
       </ol>
     </section>
@@ -28,19 +30,27 @@
                     {{ Form::open(['method' => 'GET']) }}
                         <div class="row">
                             <div class="form-group col-md-6">
-                                <label>Dictionary</label>
+                                <label>
+                                    {{ trans('translation-manager::crud.select_dictionary_label') }}
+                                </label>
                                 <select class="form-control" id="select_dictionary_by_namespace" name="dictionary" label="Dictionary" type="select" value="">
-                                    <option value="">-- Select a dictionary by namespace --</option>
+                                    <option value="">
+                                        {{ trans('translation-manager::crud.select_dictionary_default_option') }}
+                                    </option>
                                     @foreach ($dictionariesByNamespace as $namespace => $dictionaries)
                                         @
                                         @if (empty($namespace) || $namespace === '*')
                                             @foreach ($dictionaries as $dictionary => $dictionaryName)
-                                                <option value="{{ $dictionary }}" {!! $dictionary === $selectedDictionary ? 'selected="selected"' : '' !!}>{{ $dictionaryName }}</option>
+                                                <option value="{{ $dictionary }}" {!! $dictionary === $selectedDictionary ? 'selected="selected"' : '' !!}>
+                                                    {{ $dictionaryName }}
+                                                </option>
                                             @endforeach
                                         @else
                                             <optgroup label="{{ $namespace }}">
                                                 @foreach ($dictionaries as $dictionary => $dictionaryName)
-                                                    <option value="{{ $dictionary }}" {!! $dictionary === $selectedDictionary ? 'selected="selected"' : '' !!}>{{ $dictionaryName }}</option>
+                                                    <option value="{{ $dictionary }}" {!! $dictionary === $selectedDictionary ? 'selected="selected"' : '' !!}>
+                                                        {{ $dictionaryName }}
+                                                    </option>
                                                 @endforeach
                                             </optgroup>
                                         @endif
@@ -50,34 +60,40 @@
                             <!-- load the view from the application if it exists, otherwise load the one in the package -->
                             <!-- text input -->
                             <div class="form-group col-md-6">
-                                <label>Language</label>
+                                <label>
+                                    {{ trans('translation-manager::crud.select_language_label') }}
+                                </label>
                                 <select class="form-control" id="select_language" name="language" label="Language" type="select" value="">
-                                    <option value="">-- Select a language --</option>
+                                    <option value="">
+                                        {{ trans('translation-manager::crud.select_language_default_option') }}
+                                    </option>
                                     @foreach ($locales as $locale => $name)
-                                        <option value="{{ $locale }}" {!! $locale === $selectedLanguage? 'selected="selected"' : '' !!}>{{ $name }}</option>
+                                        <option value="{{ $locale }}" {!! $locale === $selectedLanguage? 'selected="selected"' : '' !!}>
+                                            {{ $name }}
+                                        </option>
                                     @endforeach
                                 </select>
                             </div>
                             <div class="form-group col-md-12">
-                                <button type="submit" class="btn btn-primary">Rechercher</button>
+                                <button type="submit" class="btn btn-primary">
+                                    {{ trans('translation-manager::crud.button_search') }}
+                                </button>
                             </div>
                         </div>
                     {{ Form::close() }}
                 </div>
                 {{ Form::open() }}
-                    <input type="hidden" name="dictionary" value="<?= $selectedDictionary ?>"/>
-                    <input type="hidden" name="language" value="<?= $selectedLanguage ?>"/>
+                    <input type="hidden" name="dictionary" value="{{ $selectedDictionary }}"/>
+                    <input type="hidden" name="language" value="{{ $selectedLanguage }}"/>
                     <div class="box-body">
                         <table id="crudTable" class="table table-bordered table-striped display dataTable" role="grid" aria-describedby="crudTable_info">
                             <thead>
                                 <tr role="row">
-                                    <th class="sorting" tabindex="0" aria-controls="crudTable" rowspan="1" colspan="1"
-                                        aria-label="Name: activate to sort column ascending">
-                                        Key
+                                    <th>
+                                        {{ trans('translation-manager::crud.column_key') }}
                                     </th>
-                                    <th class="sorting" tabindex="0" aria-controls="crudTable" rowspan="1" colspan="1"
-                                        aria-label="Template: activate to sort column ascending">
-                                        Translation
+                                    <th>
+                                        {{ trans('translation-manager::crud.column_translation') }}
                                     </th>
                                 </tr>
                             </thead>
@@ -90,35 +106,50 @@
                                             {{ $translation->key }}
                                         </td>
                                         <td valign="top" class="">
-                                            <input type="text" name="translations[{{ $translation->key }}]" value="{{ $translation->getTranslation($selectedLanguage) }}" class="form-control" />
+                                            <input type="text"
+                                                   name="translations[{{ $translation->key }}]"
+                                                   value="{{ $translation->getTranslation($selectedLanguage) }}"
+                                                   class="form-control" />
                                         </td>
                                     </tr>
                                     @endforeach
                                 @else
                                     <tr class="odd">
-                                        <td valign="top" colspan="3" class="dataTables_empty">No translations available for this dictionary.</td>
+                                        <td valign="top" colspan="3" class="dataTables_empty">
+                                            {{ trans('translation-manager::crud.list_no_translations') }}
+                                        </td>
                                     </tr>
                                 @endif
                             @else
                                 <tr class="odd">
-                                    <td valign="top" colspan="3" class="dataTables_empty">Select a dictionary and a language to display translations.</td>
+                                    <td valign="top" colspan="2" class="dataTables_empty">
+                                        {{ trans('translation-manager::crud.list_require_select') }}
+                                    </td>
                                 </tr>
                             @endif
                             </tbody>
                             <tfoot>
                                 <tr>
-                                    <th rowspan="1" colspan="1">Key</th>
-                                    <th rowspan="1" colspan="1">Translation</th>
+                                    <th>
+                                        {{ trans('translation-manager::crud.column_key') }}
+                                    </th>
+                                    <th>
+                                        {{ trans('translation-manager::crud.column_translation') }}
+                                    </th>
                                 </tr>
                             </tfoot>
                         </table>
                     </div>
-                    <div class="box-footer">
-                        <button type="submit" class="btn btn-success">
-                            <span class="fa fa-save" role="presentation" aria-hidden="true"></span> &nbsp;
-                            <span data-value="save_and_back">Save translations</span>
-                        </button>
-                    </div>
+                    @if (isset($translations))
+                        <div class="box-footer">
+                            <button type="submit" class="btn btn-success">
+                                <span class="fa fa-save" role="presentation" aria-hidden="true"></span> &nbsp;
+                                <span data-value="save_and_back">
+                                    {{ trans('translation-manager::crud.button_save') }}
+                                </span>
+                            </button>
+                        </div>
+                    @endif
                 {{ Form::close() }}
             </div>
         </div>

--- a/src/Http/Controllers/Admin/TranslationController.php
+++ b/src/Http/Controllers/Admin/TranslationController.php
@@ -71,7 +71,7 @@ class TranslationController extends Controller
         $diskTranslations = array_filter($diskTranslations, 'is_string');
 
         // Merges disk translations with DB translations
-        $translations = array_map(function ($value, $key) use ($dictionary, $language, $dbTranslations) {
+        $translations = array_map(function($value, $key) use ($dictionary, $language, $dbTranslations) {
 
             // Returns database translation prior to disk translation if exists
             foreach ($dbTranslations as $dbTranslation) {
@@ -89,7 +89,7 @@ class TranslationController extends Controller
         }, $diskTranslations, array_keys($diskTranslations));
 
         // Sorts by key to keep symmetry across languages
-        $translations = array_sort($translations, function ($translation) {
+        $translations = array_sort($translations, function($translation) {
             return $translation->key;
         });
 
@@ -149,7 +149,7 @@ class TranslationController extends Controller
         }
 
         // Converts to key/value with locale as key and display name as value
-        $locales = array_map(function ($locale) {
+        $locales = array_map(function($locale) {
             $name = \Locale::getDisplayName($locale);
             $name = mb_strtoupper(mb_substr($name, 0, 1)).mb_substr($name, 1);
 
@@ -211,9 +211,10 @@ class TranslationController extends Controller
             $namespaces = Lang::getLoader()->namespaces();
 
             // Searches for lang files in lang directories
-            $directories = array_merge([$app['path.lang']], array_values($namespaces));
+            $directories = array_merge(array($app['path.lang']), array_values($namespaces));
             foreach ($directories as $directory) {
                 foreach ($files->directories($directory) as $langPath) {
+
                     foreach ($files->allfiles($langPath) as $file) {
                         $info = pathinfo($file);
 

--- a/src/Http/Controllers/Admin/TranslationController.php
+++ b/src/Http/Controllers/Admin/TranslationController.php
@@ -71,7 +71,7 @@ class TranslationController extends Controller
         $diskTranslations = array_filter($diskTranslations, 'is_string');
 
         // Merges disk translations with DB translations
-        $translations = array_map(function($value, $key) use ($dictionary, $language, $dbTranslations) {
+        $translations = array_map(function ($value, $key) use ($dictionary, $language, $dbTranslations) {
 
             // Returns database translation prior to disk translation if exists
             foreach ($dbTranslations as $dbTranslation) {
@@ -89,7 +89,7 @@ class TranslationController extends Controller
         }, $diskTranslations, array_keys($diskTranslations));
 
         // Sorts by key to keep symmetry across languages
-        $translations = array_sort($translations, function($translation) {
+        $translations = array_sort($translations, function ($translation) {
             return $translation->key;
         });
 
@@ -149,7 +149,7 @@ class TranslationController extends Controller
         }
 
         // Converts to key/value with locale as key and display name as value
-        $locales = array_map(function($locale) {
+        $locales = array_map(function ($locale) {
             $name = \Locale::getDisplayName($locale);
             $name = mb_strtoupper(mb_substr($name, 0, 1)).mb_substr($name, 1);
 
@@ -211,10 +211,9 @@ class TranslationController extends Controller
             $namespaces = Lang::getLoader()->namespaces();
 
             // Searches for lang files in lang directories
-            $directories = array_merge(array($app['path.lang']), array_values($namespaces));
+            $directories = array_merge([$app['path.lang']], array_values($namespaces));
             foreach ($directories as $directory) {
                 foreach ($files->directories($directory) as $langPath) {
-
                     foreach ($files->allfiles($langPath) as $file) {
                         $info = pathinfo($file);
 

--- a/src/Http/Controllers/Admin/TranslationController.php
+++ b/src/Http/Controllers/Admin/TranslationController.php
@@ -71,7 +71,7 @@ class TranslationController extends Controller
         $diskTranslations = array_filter($diskTranslations, 'is_string');
 
         // Merges disk translations with DB translations
-        $translations = array_map(function($value, $key) use ($dictionary, $language, $dbTranslations) {
+        $translations = array_map(function ($value, $key) use ($dictionary, $language, $dbTranslations) {
 
             // Returns database translation prior to disk translation if exists
             foreach ($dbTranslations as $dbTranslation) {
@@ -85,11 +85,10 @@ class TranslationController extends Controller
             $translation = (new LanguageLine(['group' => $dictionary, 'key' => $key]))->setTranslation($language, $value);
 
             return $translation;
-
         }, $diskTranslations, array_keys($diskTranslations));
 
         // Sorts by key to keep symmetry across languages
-        $translations = array_sort($translations, function($translation) {
+        $translations = array_sort($translations, function ($translation) {
             return $translation->key;
         });
 
@@ -149,7 +148,7 @@ class TranslationController extends Controller
         }
 
         // Converts to key/value with locale as key and display name as value
-        $locales = array_map(function($locale) {
+        $locales = array_map(function ($locale) {
             $name = \Locale::getDisplayName($locale);
             $name = mb_strtoupper(mb_substr($name, 0, 1)).mb_substr($name, 1);
 
@@ -211,10 +210,9 @@ class TranslationController extends Controller
             $namespaces = Lang::getLoader()->namespaces();
 
             // Searches for lang files in lang directories
-            $directories = array_merge(array($app['path.lang']), array_values($namespaces));
+            $directories = array_merge([$app['path.lang']], array_values($namespaces));
             foreach ($directories as $directory) {
                 foreach ($files->directories($directory) as $langPath) {
-
                     foreach ($files->allfiles($langPath) as $file) {
                         $info = pathinfo($file);
 

--- a/src/Providers/TranslationServiceProvider.php
+++ b/src/Providers/TranslationServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Novius\Backpack\Translation\Manager;
+namespace Novius\Backpack\Translation\Manager\Providers;
 
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;

--- a/src/Providers/TranslationServiceProvider.php
+++ b/src/Providers/TranslationServiceProvider.php
@@ -33,7 +33,7 @@ class TranslationServiceProvider extends ServiceProvider
         // Publishes views/config/language
         $this->publishes([$appRootDir.'/resources/views' => base_path('resources/views')], 'views');
         $this->publishes([$appRootDir.'/config/translation-manager.php' => config_path('translation-manager.php')], 'config');
-        $this->publishes([$appRootDir.'/resources/lang' => resource_path('lang/vendor/novius')], 'lang');
+        $this->publishes([$appRootDir.'/resources/lang' => resource_path('lang/vendor/translation-manager')], 'lang');
 
         // Loads the views
         $this->loadViewsFrom(resource_path('views/vendor/novius/translation-manager'), 'translation-manager');


### PR DESCRIPTION
- New optional key `locales` in config file to manually specify the available locales instead of automatically listing them from the dictionaries found.
- Comments in config file for each key
- Lang files
- Code style rules (.php_cs + .travis.yml)
- Requires PHP 7.1
- Code cleaning